### PR TITLE
Keys

### DIFF
--- a/gdbm.go
+++ b/gdbm.go
@@ -167,12 +167,12 @@ func (db *Database) ToMap() (db_map map[string]string, err error) {
 
 	curr_k, err = db.FirstKey()
 	if err != nil {
-		return
+		return db, nil
 	}
 
 	curr_v, err = db.Fetch(curr_k)
 	if err != nil {
-		return
+		return db, nill
 	}
 
 	db_map[curr_k] = curr_v

--- a/gdbm.go
+++ b/gdbm.go
@@ -130,8 +130,9 @@ func (db *Database) Exists(key string) bool {
 	return false
 }
 
-// Returns the firstkey in this gdbm.Database. If there is not a key, an
-// error will be returned in err.
+// Returns the firstkey in this gdbm.Database.
+// The traversal is ordered by gdbm‘s internal hash values, and won’t be sorted by the key values
+// If there is not a key, an error will be returned in err.
 func (db *Database) FirstKey() (value string, err error) {
 	vdatum := C.gdbm_firstkey(db.dbf)
 	if vdatum.dptr == nil {

--- a/gdbm.go
+++ b/gdbm.go
@@ -147,7 +147,7 @@ func (db *Database) FirstKey() (value string, err error) {
 		return "", lastError()
 	}
 
-	value = C.GoString(vdatum.dptr)
+	value = C.GoStringN(vdatum.dptr, vdatum.dsize)
 	defer C.free(unsafe.Pointer(vdatum.dptr))
 	return value, nil
 }
@@ -164,7 +164,7 @@ func (db *Database) NextKey(key string) (value string, err error) {
 		return "", lastError()
 	}
 
-	value = C.GoString(vdatum.dptr)
+	value = C.GoStringN(vdatum.dptr, vdatum.dsize)
 	defer C.free(unsafe.Pointer(vdatum.dptr))
 	return value, nil
 }
@@ -176,13 +176,16 @@ func (db *Database) Fetch(key string) (value string, err error) {
 	kcs := C.CString(key)
 	k := C.mk_datum(kcs)
 	defer C.free(unsafe.Pointer(kcs))
+	return db.fetch(k)
+}
 
-	vdatum := C.gdbm_fetch(db.dbf, k)
+func (db *Database) fetch(d C.datum) (value string, err error) {
+	vdatum := C.gdbm_fetch(db.dbf, d)
 	if vdatum.dptr == nil {
 		return "", lastError()
 	}
 
-	value = C.GoString(vdatum.dptr)
+	value = C.GoStringN(vdatum.dptr, vdatum.dsize)
 	defer C.free(unsafe.Pointer(vdatum.dptr))
 	return value, nil
 }

--- a/gdbm.go
+++ b/gdbm.go
@@ -191,7 +191,7 @@ func (db *Database) ToMap() (db_map map[string]string, err error) {
 
 		curr_k = next_k
 	}
-	return
+	return db_map, nil
 }
 
 // Fetches the value of the given key. If the key is not in the database, an

--- a/gdbm.go
+++ b/gdbm.go
@@ -155,6 +155,45 @@ func (db *Database) NextKey(key string) (value string, err error) {
 	return value, nil
 }
 
+// return a map of [key]value, otherwise `err`
+func (db *Database) ToMap() (db_map map[string]string, err error) {
+	var (
+		curr_k string
+		curr_v string
+		next_k string
+		next_v string
+	)
+	db_map = make(map[string]string)
+
+	curr_k, err = db.FirstKey()
+	if err != nil {
+		return
+	}
+
+	curr_v, err = db.Fetch(curr_k)
+	if err != nil {
+		return
+	}
+
+	db_map[curr_k] = curr_v
+
+	for {
+		next_k, err = db.NextKey(curr_k)
+		if err != nil {
+			break
+		}
+
+		next_v, err = db.Fetch(next_k)
+		if err != nil {
+			break
+		}
+		db_map[next_k] = next_v
+
+		curr_k = next_k
+	}
+	return
+}
+
 // Fetches the value of the given key. If the key is not in the database, an
 // error will be returned in err. Otherwise, value will be the value string
 // that is keyed by `key`.

--- a/gdbm.go
+++ b/gdbm.go
@@ -167,12 +167,12 @@ func (db *Database) ToMap() (db_map map[string]string, err error) {
 
 	curr_k, err = db.FirstKey()
 	if err != nil {
-		return db, nil
+		return db_map, nil
 	}
 
 	curr_v, err = db.Fetch(curr_k)
 	if err != nil {
-		return db, nill
+		return db_map, nil
 	}
 
 	db_map[curr_k] = curr_v

--- a/gdbm.go
+++ b/gdbm.go
@@ -161,45 +161,6 @@ func (db *Database) NextKey(key string) (value string, err error) {
 	return value, nil
 }
 
-// return a map of [key]value, otherwise `err`
-func (db *Database) ToMap() (db_map map[string]string, err error) {
-	var (
-		curr_k string
-		curr_v string
-		next_k string
-		next_v string
-	)
-	db_map = make(map[string]string)
-
-	curr_k, err = db.FirstKey()
-	if err != nil {
-		return db_map, nil
-	}
-
-	curr_v, err = db.Fetch(curr_k)
-	if err != nil {
-		return db_map, nil
-	}
-
-	db_map[curr_k] = curr_v
-
-	for {
-		next_k, err = db.NextKey(curr_k)
-		if err != nil {
-			break
-		}
-
-		next_v, err = db.Fetch(next_k)
-		if err != nil {
-			break
-		}
-		db_map[next_k] = next_v
-
-		curr_k = next_k
-	}
-	return db_map, nil
-}
-
 // Fetches the value of the given key. If the key is not in the database, an
 // error will be returned in err. Otherwise, value will be the value string
 // that is keyed by `key`.

--- a/gdbm.go
+++ b/gdbm.go
@@ -125,6 +125,36 @@ func (db *Database) Exists(key string) bool {
 	return false
 }
 
+// Returns the firstkey in this gdbm.Database. If there is not a key, an
+// error will be returned in err.
+func (db *Database) FirstKey() (value string, err error) {
+	vdatum := C.gdbm_firstkey(db.dbf)
+	if vdatum.dptr == nil {
+		return "", lastError()
+	}
+
+	value = C.GoString(vdatum.dptr)
+	defer C.free(unsafe.Pointer(vdatum.dptr))
+	return value, nil
+}
+
+// Returns the nextkey after `key`. If there is not a next key, an
+// error will be returned in err.
+func (db *Database) NextKey(key string) (value string, err error) {
+	kcs := C.CString(key)
+	k := C.mk_datum(kcs)
+	defer C.free(unsafe.Pointer(kcs))
+
+	vdatum := C.gdbm_nextkey(db.dbf, k)
+	if vdatum.dptr == nil {
+		return "", lastError()
+	}
+
+	value = C.GoString(vdatum.dptr)
+	defer C.free(unsafe.Pointer(vdatum.dptr))
+	return value, nil
+}
+
 // Fetches the value of the given key. If the key is not in the database, an
 // error will be returned in err. Otherwise, value will be the value string
 // that is keyed by `key`.

--- a/gdbm.go
+++ b/gdbm.go
@@ -47,8 +47,16 @@ func Version() (version string) {
 	return C.GoString(C.gdbm_version)
 }
 
-// Simple function to open a database file with default parameters (block size
-// is default for the filesystem and file permissions are set to 0666).
+/*
+Simple function to open a database file with default parameters (block size
+is default for the filesystem and file permissions are set to 0666).
+
+mode is one of:
+  "r" - reader
+  "w" - writer
+  "c" - rw / create
+  "n" - new db
+*/
 func Open(filename string, mode string) (db *Database, err error) {
 	return OpenWithCfg(filename, DatabaseCfg{mode, 0, 0666})
 }

--- a/gdbm_test.go
+++ b/gdbm_test.go
@@ -59,7 +59,7 @@ func TestKeys(t *testing.T) {
 		t.Error(err)
 	}
 	if !ListContains(expected_keys, k) {
-    t.Errorf("FirstKey() expected: %s", expected_keys)
+		t.Errorf("FirstKey() expected: %s", expected_keys)
 	}
 
 	for i := 1; i < len(expected_keys); i++ {
@@ -68,7 +68,7 @@ func TestKeys(t *testing.T) {
 			t.Error(err)
 		}
 		if !ListContains(expected_keys, n) {
-      t.Errorf("NextKey() expected: %s", expected_keys)
+			t.Errorf("NextKey() expected: %s", expected_keys)
 		}
 	}
 

--- a/gdbm_test.go
+++ b/gdbm_test.go
@@ -13,9 +13,19 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+/* returns true if str is a word in list */
+func ListContains(list []string, str string) bool {
+	for i := range list {
+		if list[i] == str {
+			return true
+		}
+	}
+	return false
+}
+
 // Create a database, insert two rows, and check that FirstKey, and NextKey return those keys
 func TestKeys(t *testing.T) {
-  var db_filename string = "test.gdbm" // pending the test_cleanup merge
+	var db_filename string = "test.gdbm" // pending the test_cleanup merge
 
 	os.Remove(db_filename) // pending the test_cleanup merge
 	db, err := Open(db_filename, "c")
@@ -33,22 +43,34 @@ func TestKeys(t *testing.T) {
 	if err != nil {
 		t.Error("Database let readonly client write")
 	}
+	err = db.Insert("biff", "bixx")
+	if err != nil {
+		t.Error("Database let readonly client write")
+	}
 
-  k,err := db.FirstKey()
-  if err != nil {
-    t.Error(err)
-  }
-  if k != "foo" && k != "baz" {
-    t.Error("FirstKey() expected 'foo' or 'baz'")
-  }
+	expected_keys := []string{
+		"foo",
+		"baz",
+		"biff",
+	}
 
-  n,err := db.NextKey(k)
-  if err != nil {
-    t.Error(err)
-  }
-  if n != "foo" && n != "baz" {
-    t.Error("NextKey() expected 'foo' or 'baz'")
-  }
+	k, err := db.FirstKey()
+	if err != nil {
+		t.Error(err)
+	}
+	if !ListContains(expected_keys, k) {
+    t.Errorf("FirstKey() expected: %s", expected_keys)
+	}
+
+	for i := 1; i < len(expected_keys); i++ {
+		n, err := db.NextKey(k)
+		if err != nil {
+			t.Error(err)
+		}
+		if !ListContains(expected_keys, n) {
+      t.Errorf("NextKey() expected: %s", expected_keys)
+		}
+	}
 
 }
 

--- a/gdbm_test.go
+++ b/gdbm_test.go
@@ -13,11 +13,50 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+// Create a database, insert two rows, and check that FirstKey, and NextKey return those keys
+func TestKeys(t *testing.T) {
+  var db_filename string = "test.gdbm" // pending the test_cleanup merge
+
+	os.Remove(db_filename) // pending the test_cleanup merge
+	db, err := Open(db_filename, "c")
+	if err != nil {
+		t.Error("Couldn't create new database")
+	}
+	defer db.Close()
+	defer os.Remove(db_filename)
+
+	err = db.Insert("foo", "bar")
+	if err != nil {
+		t.Error("Database let readonly client write")
+	}
+	err = db.Insert("baz", "bax")
+	if err != nil {
+		t.Error("Database let readonly client write")
+	}
+
+  k,err := db.FirstKey()
+  if err != nil {
+    t.Error(err)
+  }
+  if k != "foo" && k != "baz" {
+    t.Error("FirstKey() expected 'foo' or 'baz'")
+  }
+
+  n,err := db.NextKey(k)
+  if err != nil {
+    t.Error(err)
+  }
+  if n != "foo" && n != "baz" {
+    t.Error("NextKey() expected 'foo' or 'baz'")
+  }
+
+}
+
 // Tests that the database is recreated everytime when opened in "c" mode.
 // Ensures that the file exists and that there are no key-value pairs.
 func TestRecreate(t *testing.T) {
 	db, err := Open("test.gdbm", "c")
-	defer db.Close()
+	db.Close() // pending the test_cleanup merge
 
 	if err != nil {
 		t.Error("Couldn't create new database")


### PR DESCRIPTION
regarding: issue #1

Adding three new instance methods. 
Two are from gdbm.h (gdbm_firstkey and gdbm_nextkey). These are in and working as expected.

The third is a golang only method, (ToMap). The logic is mostly there, but is including a value that appears to be a memory address.

So the current usage is 
```go
db, _ := gdbm.Open("derp.db", "c")
defer db.Close()

db.Insert("a","apple")
db.Insert("b","banana")

db_map, _ := db.ToMap()
for k,v := range db_map {
    println(k)
    println(v)
}
```

but presently this is outputting
a
(0x1850b380,0x185000c8)
b
banana
a
apple

