### PR TITLE
Mark mk_datum as static because otherwise it is optimized away when built with CGO_CFLAGS="-O0 -g"

### DIFF
--- a/gdbm.go
+++ b/gdbm.go
@@ -7,7 +7,7 @@ package gdbm
 // #include <stdlib.h>
 // #include <gdbm.h>
 // #include <string.h>
-// inline datum mk_datum(char * s) {
+// static inline datum mk_datum(char * s) {
 //     datum d;
 //     d.dptr = s;
 //     d.dsize = strlen(s);


### PR DESCRIPTION
cc @cfdrake 
see these issues:
https://github.com/golang/go/issues/41727
https://github.com/go-delve/delve/issues/2187